### PR TITLE
git: Panic if ssh key file is not found

### DIFF
--- a/bors/src/git.rs
+++ b/bors/src/git.rs
@@ -217,6 +217,9 @@ impl Git {
         } else {
             std::env::current_dir().unwrap().join(ssh_key_file)
         };
+        if !path.is_file() {
+            panic!("SSH Key File is not a file")
+        };
         self.inner.env(
             "GIT_SSH_COMMAND",
             format!("ssh -i {} -S none -o 'IdentitiesOnly true'", path.display()),


### PR DESCRIPTION
The reading of the ssh-key-file occurs at the time git uses the
`GIT_SSH_COMMAND`, which is interpreted by a shell for `git fetch` and
`git pull`

Verification that the identity file exists should occur, and the program
should exit early if it does not exist.

Changes:
- checks ssh-key-file exists on disk as a file

Test:

- Create a file `touch test.txt`
- Update `bors.toml` value for `ssh-key-file` to be `test.txt`
- Run `rm -rf repos/ # triggers cloning of repo, when incident occurs; cargo run -- -c bors.toml serve`
- Verify `cloning <repo> to <repo-path>` in `bors` logging output
  - `[2020-08-28T19:05:44Z INFO  bors::git] cloning 'git@github.com:jnaulty/spoon-fork-bors.git' to '/home/jnaulty/github.com/bors-rs/bors/repos/jnaulty/spoon-fork-bors'`
- Update `bors.toml` value for `ssh-key-file` to be `test.txt; echo $(whoami) > /tmp/whoami.txt`
- Run `rm -f /tmp/whoami.txt; rm -rf repos/ # triggers cloning of repo, when incident occurs; cargo run -- -c bors.toml serve`
- Verify panic occurs and the file `/tmp/whoami.txt` does not exist