### PR TITLE
[webhook] Modernize Bors with SHA-256 and duplicate protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 bors.toml
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # A merge bot for GitHub pull requests
 
-Bors is a Github App used to manage merging of PRs in order to ensure that CI is always green. 
-It does so by maintaining a Merge Queue. 
-Once a PR reaches the head of the Merge Queue it is rebased on top of the latest version of the PR's base-branch (generally master) and then triggers CI. 
-If CI comes back green the PR is then merged into the base-branch. 
+Bors is a Github App used to manage merging of PRs in order to ensure that CI is always green.
+It does so by maintaining a Merge Queue.
+Once a PR reaches the head of the Merge Queue it is rebased on top of the latest version of the PR's base-branch (generally master) and then triggers CI.
+If CI comes back green the PR is then merged into the base-branch.
 Regardless of the outcome, the next PR is the queue is then processed.
 
 
@@ -26,11 +26,52 @@ Requires:
 - ssh key added to github user account
 - setup a webhook pointing to the bors server using the `/github` endpoint
 
+1. Create a Github [application](https://docs.github.com/en/developers/apps/building-github-apps/creating-a-github-app) e.g. `bors-app`
+   1. Put `bors-<your_name>` as the application name
+   2. Put this repo's address as the homepage URL e.g. https://github.com/bors-rs/bors
+   3. Activate webhook, and put the URL to your server/github e.g. https://my-bors.domain/github
+   4. Repository Permissions
+      * Actions - Read and Write
+      * Checks - Read and Write
+      * Commit statuses - Read and Write
+      * Contents - Read and Write
+      * Deployments - Read-only
+      * Issues - Read and Write
+      * Metadata - Read-only
+      * Projects - Read and Write
+      * Pull Requests - Read and Write
+   5. Subscribe To Events
+      * Meta
+      * Check Run
+      * Commit comment
+      * Deployment Review
+      * Issue Comment
+      * Issues
+      * Label
+      * Project
+      * Project Card
+      * Project Column
+      * Pull Request
+      * Pull Request Review
+      * Pull Request Review Comment
+      * Pull Request Review Thread
+      * Push
+      * Repository
+      * Status
+      * Workflow Dispatch
+      * Workflow Job
+      * Workflow Run
+2. Create a Github [machine user](https://docs.github.com/en/developers/overview/managing-deploy-keys#machine-users) e.g. bors
+3. Create a GitHub personal access token in the `bot` account. Add it to the bors config under `github/api-token`.
+4. Create an SSH key in the `bot` account.  Provide this key locally on the bot's machine. Add it to the bors config under `git/ssh-key-file`.
+5. Add a webhook for the repo that points to the bors server using the `/github` endpoint.  Configure it to use `application-json`, and provide the secret under `github/webhook-secret`
+6. Add any CI and appropriate SSH Keys.  CircleCI requires an SSH key for a machine user for multiple repos (e.g. the bot above).  Then, it can be added as dependent steps in the config.
+7. Startup a server with appropriate commands that's configured to receive messages.  You can open the server's main page for status, and repo specific status by clicking on the repos.
 
 ### Running
 
 ```
-➜  bors git:(jnaulty/fix-typo) ✗ cargo run -- -c bors.toml serve 
+➜  bors git:(jnaulty/fix-typo) ✗ cargo run -- -c bors.toml serve
    Compiling bors v0.0.0 (/home/jnaulty/github.com/bors-rs/bors/bors)
     Finished dev [unoptimized + debuginfo] target(s) in 13.74s
      Running `target/debug/bors -c bors.toml serve`
@@ -42,6 +83,18 @@ Requires:
 [2020-08-28T09:19:58Z INFO  bors::event_processor] Done Synchronizing
 ```
 
+### How does it work?
+
+#### On commands
+* Bors listens for pull request interactions (e.g. `/land`) in comments.
+* Bors receives webhook messages and it scans for those interactions.
+* Bors then will determine whether the PR has the appropriate approvals.
+* After that, bors will move the commits to either the `auto`(for `/land`) or `canary`(for `/canary`) branches to run testing separately.
+* Bors waits on webhook responses telling it that CI passed for the configured checks.
+* It will then merge them into the `main` branch if it's a `/land` command or provide a summary for a `/canary` command.
+
+#### State
+* Bors uses a Github project to keep track of state.  It moves the PRs between stages to determine whether it is queued, testing, or in review.
 
 ##  Pull Request Interactions
 
@@ -64,4 +117,3 @@ Options for Pull Requests are configured through the application of labels.
 | ![label: bors-high-priority](https://img.shields.io/static/v1?label=&message=bors-high-priority&color=lightgrey) | Indicates that the PR is high-priority. When queued the PR will be placed at the head of the merge queue. |
 | ![label: bors-low-priority](https://img.shields.io/static/v1?label=&message=bors-low-priority&color=lightgrey) | Indicates that the PR is low-priority. When queued the PR will be placed at the back of the merge queue. |
 | ![label: bors-squash](https://img.shields.io/static/v1?label=&message=bors-squash&color=lightgrey) | Before merging the PR will be squashed down to a single commit, only retaining the commit message of the first commit in the PR. |
-

--- a/bors/Cargo.toml
+++ b/bors/Cargo.toml
@@ -17,6 +17,7 @@ hyper-tls = "0.5"
 reqwest = "0.11"
 liquid = "0.21"
 log = "0.4.8"
+lru = "0.7.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 structopt = "0.3.11"

--- a/bors/src/project_board.rs
+++ b/bors/src/project_board.rs
@@ -1,3 +1,4 @@
+use crate::event_processor::ActivePullRequestContext;
 use crate::{
     config::RepoConfig,
     graphql::GithubClient,
@@ -186,7 +187,6 @@ impl ProjectBoard {
         let canary_column =
             Self::unwrap_or_create_column(canary_column, CANARY_COLUMN_NAME, project_id, github)
                 .await?;
-
         Ok((review_column, queued_column, testing_column, canary_column))
     }
 
@@ -261,7 +261,14 @@ impl ProjectBoard {
         Ok(())
     }
 
-    async fn list_cards(github: &GithubClient, column_id: u64) -> Result<Vec<ProjectCard>> {
+    pub async fn list_canary_cards(
+        &self,
+        ctx: &ActivePullRequestContext<'_>,
+    ) -> Result<Vec<ProjectCard>> {
+        Self::list_cards(ctx.github(), self.canary_column.id).await
+    }
+
+    pub async fn list_cards(github: &GithubClient, column_id: u64) -> Result<Vec<ProjectCard>> {
         let mut list_options = ListProjectCardsOptions {
             archived_state: None,
             pagination_options: PaginationOptions {

--- a/bors/src/server/mod.rs
+++ b/bors/src/server/mod.rs
@@ -9,7 +9,10 @@ pub use self::{installation::Installation, smee_client::SmeeClient};
 use crate::{config::GithubConfig, Error, Result};
 use anyhow::anyhow;
 use futures::future::{self, TryFutureExt};
-use github::{EventType, Webhook, DELIVERY_ID_HEADER, EVENT_TYPE_HEADER, SIGNATURE_HEADER};
+use github::{
+    EventType, Webhook, DELIVERY_ID_HEADER, EVENT_TYPE_HEADER, SIGNATURE_256_HEADER,
+    SIGNATURE_HEADER,
+};
 use hyper::{
     body,
     header::{HeaderValue, CONTENT_LENGTH, CONTENT_TYPE},
@@ -208,7 +211,10 @@ impl Server {
     pub(super) async fn handle_webhook(&mut self, webhook: Webhook) -> Result<()> {
         trace!("Handling Webhook: {}", webhook.delivery_id);
         if !webhook.check_signature(self.config.webhook_secret().map(str::as_bytes)) {
-            warn!("Signature check FAILED! Skipping Event.");
+            warn!(
+                "Signature check FAILED! Skipping Event. [{:?},{}]",
+                webhook.event_type, webhook.delivery_id
+            );
             return Ok(());
         }
 
@@ -282,12 +288,22 @@ async fn webhook_from_request(request: Request<Body>) -> Result<Webhook> {
         _ => None,
     };
 
+    let signature_256 = match request
+        .headers()
+        .get(SIGNATURE_256_HEADER)
+        .and_then(|h| HeaderValue::to_str(h).ok())
+    {
+        Some(signature) => Some(signature.to_owned()),
+        _ => None,
+    };
+
     let body = body::to_bytes(request.into_body()).await?.to_vec();
 
     Ok(Webhook {
         event_type,
         delivery_id,
         signature,
+        signature_256,
         body,
     })
 }

--- a/bors/src/server/smee_client.rs
+++ b/bors/src/server/smee_client.rs
@@ -80,6 +80,8 @@ struct SmeeMessage<'a> {
     delivery_id: String,
     #[serde(rename = "x-hub-signature")]
     signature: Option<String>,
+    #[serde(rename = "x-hub-signature-256")]
+    signature_256: Option<String>,
 }
 
 struct ServerSentEvent<'a> {
@@ -139,6 +141,7 @@ impl<'b> SmeeEventParser<'b> {
                     event_type: smee_msg.event_type,
                     delivery_id: smee_msg.delivery_id,
                     signature: smee_msg.signature,
+                    signature_256: smee_msg.signature_256,
                     body: smee_msg.event.get().as_bytes().to_owned(),
                 };
                 SmeeEvent::Message(webhook)

--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 chrono = "0.4"
 graphql_client = { version = "0.9.0", optional = true }
 hex = "0.4.2"
+hmac-sha256 = "1.1.2"
 hmac-sha1 = "0.1.3"
 log = "0.4.8"
 reqwest = { version = "0.11", features = ["json"] }

--- a/github/src/webhook.rs
+++ b/github/src/webhook.rs
@@ -50,7 +50,10 @@ impl Webhook {
                 );
                 signature == hash
             } else {
-                warn!("[webhook {}] Invalid signature header {}", self.delivery_id, signature);
+                warn!(
+                    "[webhook {}] Invalid signature header {}",
+                    self.delivery_id, signature
+                );
                 false
             }
         } else {

--- a/github/src/webhook.rs
+++ b/github/src/webhook.rs
@@ -38,24 +38,15 @@ impl Webhook {
             return false;
         }
 
-        // Signature should have `sha256=` in front
         if let Some(ref signature) = self.signature_256 {
-            if !signature.starts_with("sha256=") {
-                let hash = hex::encode(hmac_sha256::HMAC::mac(&self.body, key.unwrap()));
-                let signature = &signature["sha256=".len()..];
+            let hash = hex::encode(hmac_sha256::HMAC::mac(&self.body, key.unwrap()));
+            let signature = &signature["sha256=".len()..];
 
-                debug!(
-                    "[webhook {}] SHA-256 Found: {} Expected: {}",
-                    self.delivery_id, signature, hash
-                );
-                signature == hash
-            } else {
-                warn!(
-                    "[webhook {}] Invalid signature header {}",
-                    self.delivery_id, signature
-                );
-                false
-            }
+            debug!(
+                "[webhook {}] SHA-256 Found: {} Expected: {}",
+                self.delivery_id, signature, hash
+            );
+            signature == hash
         } else {
             // There is no signature, reject it
             warn!("[webhook {}] No signature present", self.delivery_id);


### PR DESCRIPTION
Bors was using a legacy SHA-1 hash check for incoming webhook messages.  Additionally, many times duplicate webhook messages would come into the system.  This now uses an LRU cache to keep track of webhook messages for a short period of time to keep track of duplicates, as well as using a SHA-256 hash check to be more secure.